### PR TITLE
Add output to expose the Global-Acc Route 53 Zone ID

### DIFF
--- a/.github/auto-release.yml
+++ b/.github/auto-release.yml
@@ -17,7 +17,6 @@ version-resolver:
     - 'bugfix'
     - 'bug'
     - 'hotfix'
-    - 'no-release'
   default: 'minor'
 
 categories:

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -4,9 +4,9 @@
     ":preserveSemverRanges"
   ],
   "labels": ["auto-update"],
+  "dependencyDashboardAutoclose": true,
   "enabledManagers": ["terraform"],
   "terraform": {
     "ignorePaths": ["**/context.tf", "examples/**"]
   }
 }
-

--- a/README.md
+++ b/README.md
@@ -301,6 +301,7 @@ Available targets:
 | Name | Description |
 |------|-------------|
 | <a name="output_dns_name"></a> [dns\_name](#output\_dns\_name) | DNS name of the Global Accelerator. |
+| <a name="output_hosted_zone_id"></a> [hosted\_zone\_id](#output\_hosted\_zone\_id) | Route 53 zone ID that can be used to route an Alias Resource Record Set to the Global Accelerator. |
 | <a name="output_listener_ids"></a> [listener\_ids](#output\_listener\_ids) | Global Accelerator Listener IDs. |
 | <a name="output_name"></a> [name](#output\_name) | Name of the Global Accelerator. |
 | <a name="output_static_ips"></a> [static\_ips](#output\_static\_ips) | Global Static IPs owned by the Global Accelerator. |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -58,6 +58,7 @@
 | Name | Description |
 |------|-------------|
 | <a name="output_dns_name"></a> [dns\_name](#output\_dns\_name) | DNS name of the Global Accelerator. |
+| <a name="output_hosted_zone_id"></a> [hosted\_zone\_id](#output\_hosted\_zone\_id) | Route 53 zone ID that can be used to route an Alias Resource Record Set to the Global Accelerator. |
 | <a name="output_listener_ids"></a> [listener\_ids](#output\_listener\_ids) | Global Accelerator Listener IDs. |
 | <a name="output_name"></a> [name](#output\_name) | Name of the Global Accelerator. |
 | <a name="output_static_ips"></a> [static\_ips](#output\_static\_ips) | Global Static IPs owned by the Global Accelerator. |

--- a/outputs.tf
+++ b/outputs.tf
@@ -8,6 +8,11 @@ output "dns_name" {
   value       = try(aws_globalaccelerator_accelerator.default[0].dns_name, null)
 }
 
+output "hosted_zone_id" {
+  description = "Route 53 zone ID that can be used to route an Alias Resource Record Set to the Global Accelerator."
+  value       = try(aws_globalaccelerator_accelerator.default[0].hosted_zone_id, null)
+}
+
 output "listener_ids" {
   description = "Global Accelerator Listener IDs."
   value       = [for global_accelerator_listener in aws_globalaccelerator_listener.default : global_accelerator_listener.id]


### PR DESCRIPTION
The Global Accelerator Route 53 zone ID is required to route an Alias Resource Record Set to the Global Accelerator

## what
* Add an output to expose hosted_zone_id of the Global Accelerator

## why
* This is required when creating a Route 53 record of type "Alias" that points to the Global Accelerator

## references
* https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/globalaccelerator_accelerator#hosted_zone_id

